### PR TITLE
Modernise build and consolidate into single config file

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Edit .github/**",
+      "Edit cmd/**",
+      "Edit app/**",
+      "Edit config/**",
+      "Edit Makefile",
+      "Edit CLAUDE.md",
+      "Edit CHANGELOG.md",
+      "Bash(go:*)",
+      "Bash(go run *)",
+      "Bash(go build *)",
+      "Bash(go test *)",
+      "Bash(go mod *)",
+      "Bash(make test)",
+      "Bash(make lint)",
+      "Bash(make fmt)",
+      "Bash(make checkfmt)",
+      "Bash(make vet)"
+    ],
+    "deny": [
+      "Edit .claude/**",
+      "Bash(rm -rf *)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,13 +2,13 @@
   "permissions": {
     "allow": [
       "Bash(git *)",
-      "Edit .github/**",
-      "Edit cmd/**",
-      "Edit app/**",
-      "Edit config/**",
-      "Edit Makefile",
-      "Edit CLAUDE.md",
-      "Edit CHANGELOG.md",
+      "Edit(.github/**)",
+      "Edit(cmd/**)",
+      "Edit(app/**)",
+      "Edit(config/**)",
+      "Edit(Makefile)",
+      "Edit(CLAUDE.md)",
+      "Edit(CHANGELOG.md)",
       "Bash(go:*)",
       "Bash(go run *)",
       "Bash(go build *)",
@@ -21,7 +21,7 @@
       "Bash(make vet)"
     ],
     "deny": [
-      "Edit .claude/**",
+      "Edit(.claude/**)",
       "Bash(rm -rf *)"
     ]
   }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,37 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
-        go-version: '^1.23.0'
+        go-version-file: go.mod
 
-    - name: Cache Go modules
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+    - name: Install dependencies
+      run: go mod download
 
-    - name: Install
-      run: go get -t -v ./...
+    - name: Check format
+      run: |
+        if [ -n "$(gofmt -l .)" ]; then
+          echo "Go code is not formatted. Run 'make fmt'."
+          gofmt -d .
+          exit 1
+        fi
+
+    - name: Vet
+      run: make vet 
+      
+    - name: Download custom-gcl
+      run: |
+        curl -sL "https://github.com/smeshkov/golangci-lint-plugins/releases/download/${CUSTOM_GCL_VERSION}/custom-gcl-linux-amd64.tar.gz" | tar xz
+        chmod +x custom-gcl
+
+    - name: Lint
+      run: ./custom-gcl run ./...
 
     - name: Test
-      run: go test -coverprofile=coverage.txt -covermode=atomic ./...
+      run: go test -v ./...
 
     - name: Get the version 
       id: get_version 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ '*' ]
 
 env:
-  CUSTOM_GCL_VERSION: v0.0.5
+  CUSTOM_GCL_VERSION: v0.0.6
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,31 +4,45 @@ on:
   push:
     branches: [ '*' ]
 
+env:
+  CUSTOM_GCL_VERSION: v0.0.5
+
 jobs:
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
-        go-version: '^1.23.0'
+        go-version-file: go.mod
 
-    - name: Cache Go modules
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Install
-      run: go get -t -v ./...
+    - name: Install dependencies
+      run: go mod download
 
     - name: Build
       run: go build -v ./...
 
+    - name: Check format
+      run: |
+        if [ -n "$(gofmt -l .)" ]; then
+          echo "Go code is not formatted. Run 'make fmt'."
+          gofmt -d .
+          exit 1
+        fi
+
+    - name: Vet
+      run: make vet 
+      
+    - name: Download custom-gcl
+      run: |
+        curl -sL "https://github.com/smeshkov/golangci-lint-plugins/releases/download/${CUSTOM_GCL_VERSION}/custom-gcl-linux-amd64.tar.gz" | tar xz
+        chmod +x custom-gcl
+
+    - name: Lint
+      run: ./custom-gcl run ./...
+
     - name: Test
-      run: go test -coverprofile=_dist/coverage.out -v ./...
+      run: go test -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - modernfor
+    - useany
+  settings:
+    custom:
+      modernfor:
+        type: module
+        description: Enforces Go 1.22 range over int
+      useany:
+        type: module
+        description: Enforces using 'any' instead of 'interface{}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+gomock is a lightweight HTTP mock server written in Go. It serves mocked JSON responses based on a JSON configuration file, supporting static responses, proxying, dynamic read/write storage, CORS, configurable error simulation, and hot-reload of config files via fsnotify.
+
+## Development process
+
+- `make checkfmt`, `make lint` and `make test` must pass.
+- always make sure to add tests for any new code you write.
+- tests should be placed next to the code they test.
+
+## Common Commands
+
+- **Build:** `make build` (outputs to `_dist/`, defaults to darwin/arm64)
+- **Run:** `make run` (runs with `_dist/mock.json`, watch mode, verbose)
+- **Run directly:** `go run cmd/app/main.go -mock <path-to-mock.json> [-watch] [-verbose]`
+- **Test:** `make test` (runs `gofmt`, `staticcheck`, `go test -v ./...` with coverage)
+- **Run a single test:** `go test -v -run TestFunctionName ./app/...`
+- **Install locally:** `make install` (builds and copies binary to `~/bin/gomock`)
+
+## Architecture
+
+The entrypoint is `cmd/app/main.go`. It loads two configs:
+- **App config** (`_resources/config.yml` via `-config` flag): YAML file for server settings (timeouts, address, log level). Parsed in `config/config.go`.
+- **Mock config** (`mock.json` via `-mock` flag): JSON file defining endpoint behaviors. Parsed in `config/mock.go` into `config.Mock` / `config.Endpoint` structs.
+
+The main loop supports hot-reload: when `-watch` is set, file changes trigger server restart via context cancellation.
+
+`app/` contains the HTTP layer:
+- `app.go` — Registers routes on a `chi.Mux` router, defines `appHandler`/`appError` pattern for consistent error handling.
+- `handlers.go` — `setupAPI()` iterates mock endpoints and registers chi routes. `apiHandler()` is the core handler implementing: delay simulation, sampled error injection, proxying, static JSON responses, `jsonPath` file serving, and dynamic store read/write.
+- `store.go` — In-memory key-value store (`sync.RWMutex`-based) for dynamic mock data.
+- `proxy.go` — Reverse proxy wrapper.
+- `cors.go` — CORS middleware.
+
+## Key Dependencies
+
+- `go-chi/chi/v5` — HTTP router (replaced gorilla/mux; README references to gorilla mux path syntax are outdated)
+- `go.uber.org/zap` — Structured logging
+- `gopkg.in/fsnotify.v1` — File watching for hot-reload
+- `stretchr/testify` — Test assertions

--- a/Makefile
+++ b/Makefile
@@ -19,20 +19,34 @@ clean:
 build:
 	./_bin/build.sh ${OS} ${VERSION} ${ARCH}
 
+checkfmt: ## Check if the code is formatted
+	@if [ -n "$$(gofmt -l .)" ]; then \
+		echo "Go code is not formatted. Run 'make fmt'."; \
+		gofmt -d .; \
+		exit 1; \
+	fi
+
+fmt: ## Format the code
+	go fmt ./...
+
+vet: ## Run go vet
+	go vet ./...
+
+lint: ## Run custom-gcl if installed
+	@if command -v custom-gcl > /dev/null; then \
+		custom-gcl run; \
+	else \
+		echo "custom-gcl not installed (go to https://github.com/smeshkov/golangci-lint-plugins), skipping..."; \
+	fi
+
 test:
 	./_bin/test.sh
-
-# run:
-# 	./_dist/${BINARY}_${OS}_${ARCH}_${VERSION} -mock ${MOCK}
 
 run:
 	go run cmd/app/main.go -mock ${MOCK} -watch -verbose
 
 tag:
 	./_bin/tag.sh ${TAG}
-
-# install:
-# 	./_bin/install.sh ${OS} ${ARCH}
 
 install: build
 	chmod +x ${DIST_DIR}/${BINARY}_${OS}_${ARCH}_${VERSION}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Use `gomock --help` for more information.
 ```json
 {
   "port": 8080,
+  "readTimeout": "300s",
+  "writeTimeout": "300s",
+  "logLevel": "info",
   "endpoints": [
     {
       "methods": ["GET"],
@@ -71,7 +74,7 @@ Use `gomock --help` for more information.
       "methods": ["POST"],
       "path": "/api/*",
       "delay": 200,
-      "url": "http://localhost:8090"
+      "proxy": "http://localhost:8090"
     }
   ]
 }
@@ -80,6 +83,11 @@ Use `gomock --help` for more information.
 Mock JSON configuration properties:
 
 - `port` - optional (defaults to 8080);
+- `addr` - optional server address (e.g. `:3000`), overrides `port` if both set;
+- `readTimeout` - optional read timeout as a Go duration string (e.g. `"300s"`), defaults to `"5s"`;
+- `writeTimeout` - optional write timeout as a Go duration string, defaults to `"5s"`;
+- `idleTimeout` - optional idle timeout as a Go duration string, defaults to `"5s"`;
+- `logLevel` - optional log level (`"info"` or `"debug"`), defaults to `"info"`;
 - `endpoints` - an array of endpoints to configure;
 
 Endpoint object in `endpoints` list:
@@ -94,8 +102,7 @@ Endpoint object in `endpoints` list:
 - `static` - serves static files;
 - `errors` - helps to setup sampled errors, with the randomised error codes;
 - `allowCors` - list of allowed domains for CORS;
-- `dynamic` - allows to configure dynamic read/write behaviour, i.e. values can be stored and retrieved from the inetrnal store.
-- `watch` - allows to watch over the config files changes and reload automatically.
+- `dynamic` - allows to configure dynamic read/write behaviour, i.e. values can be stored and retrieved from the internal store.
 
 `mock.json` is the default name for a mock configuration file, it can be renamed and set via `-mock` option, e.g. `./gomock -mock api.json`
 
@@ -134,7 +141,7 @@ For reads use `dynamic.read.json`:
   "endpoints": [
     {
       "methods": ["GET"],
-      "path": "/note/{noteID:[a-zA-Z0-9-]+}", // uses Gorilla Mux paths
+      "path": "/note/{noteID:[a-zA-Z0-9-]+}", // uses chi paths
       "dynamic": {
         "read": {
           "json": {

--- a/app/app.go
+++ b/app/app.go
@@ -59,7 +59,7 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // }
 
 // writeResponse writes response to provided ResponseWriter in JSON format.
-func writeResponse(rw http.ResponseWriter, response interface{}) *appError {
+func writeResponse(rw http.ResponseWriter, response any) *appError {
 	rw.Header().Set("Content-Type", "application/json")
 	err := json.NewEncoder(rw).Encode(response)
 	if err != nil {

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -248,19 +248,20 @@ func readJSON(mockPath, jsonPath string) ([]byte, error) {
 
 func findKeyInJSON(path string, obj map[string]interface{}) (string, error) {
 	parts := strings.Split(path, "/")
-	v := obj
+	var current interface{} = obj
 	for i, p := range parts {
-		v, ok := v[p]
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("error in traversing request JSON, value of [%s] is not an object for the key [%s]", p, path)
+		}
+		val, ok := m[p]
 		if !ok {
 			return "", fmt.Errorf("error in traversing request JSON, attribute [%s] not found for the key [%s]", p, path)
 		}
 		if i < len(parts)-1 {
-			v, ok = v.(map[string]interface{})
-			if !ok {
-				return "", fmt.Errorf("error in traversing request JSON, value of [%s] is not an object for the key [%s]", p, path)
-			}
+			current = val
 		} else {
-			s, ok := v.(string)
+			s, ok := val.(string)
 			if !ok {
 				return "", fmt.Errorf("error in traversing request JSON, value of key [%s] is not a string for the key [%s]", p, path)
 			}
@@ -272,23 +273,24 @@ func findKeyInJSON(path string, obj map[string]interface{}) (string, error) {
 
 func findValueInJSON(path string, obj map[string]interface{}) (interface{}, error) {
 	parts := strings.Split(path, "/")
-	v := obj
+	var current interface{} = obj
 	for i, p := range parts {
 		if p == "" || p == "." {
 			continue
 		}
-		v, ok := v[p]
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("error in traversing request JSON, value of [%s] is not an object for the value [%s]", p, path)
+		}
+		val, ok := m[p]
 		if !ok {
 			return "", fmt.Errorf("error in traversing request JSON, attribute [%s] not found for the value [%s]", p, path)
 		}
 		if i < len(parts)-1 {
-			v, ok = v.(map[string]interface{})
-			if !ok {
-				return "", fmt.Errorf("error in traversing request JSON, value of [%s] is not an object for the value [%s]", p, path)
-			}
+			current = val
 		} else {
-			return v, nil
+			return val, nil
 		}
 	}
-	return v, nil
+	return current, nil
 }

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -21,7 +21,7 @@ import (
 
 // GET /healthcheck
 func healthcheckHandler(w http.ResponseWriter, r *http.Request) *appError {
-	return writeResponse(w, map[string]interface{}{
+	return writeResponse(w, map[string]any{
 		"status": "OK",
 	})
 }
@@ -29,7 +29,7 @@ func healthcheckHandler(w http.ResponseWriter, r *http.Request) *appError {
 // GET /version
 func versionHandler(version string) func(rw http.ResponseWriter, req *http.Request) *appError {
 	return func(w http.ResponseWriter, r *http.Request) *appError {
-		return writeResponse(w, map[string]interface{}{
+		return writeResponse(w, map[string]any{
 			"version": version,
 		})
 	}
@@ -92,7 +92,7 @@ func apiHandler(log *zap.Logger, endpoint *config.Endpoint, status int,
 		// Dynamic read/write operation
 		if endpoint.Dynamic != nil {
 			if endpoint.Dynamic.Write != nil {
-				input := map[string]interface{}{}
+				input := map[string]any{}
 				appErr := readRequestJSON(r.Context(), r, &input)
 				if appErr != nil {
 					return appErr
@@ -117,7 +117,7 @@ func apiHandler(log *zap.Logger, endpoint *config.Endpoint, status int,
 				db.Write(endpoint.Dynamic.Write.JSON.Name, key, value)
 			} else if endpoint.Dynamic.Read != nil {
 				var key string
-				var value interface{}
+				var value any
 				var ok bool
 				if endpoint.Dynamic.Read.JSON.KeyParam == "" {
 					value, ok = db.ReadAll(endpoint.Dynamic.Read.JSON.Name)
@@ -246,11 +246,11 @@ func readJSON(mockPath, jsonPath string) ([]byte, error) {
 	return os.ReadFile(p)
 }
 
-func findKeyInJSON(path string, obj map[string]interface{}) (string, error) {
+func findKeyInJSON(path string, obj map[string]any) (string, error) {
 	parts := strings.Split(path, "/")
-	var current interface{} = obj
+	var current any = obj
 	for i, p := range parts {
-		m, ok := current.(map[string]interface{})
+		m, ok := current.(map[string]any)
 		if !ok {
 			return "", fmt.Errorf("error in traversing request JSON, value of [%s] is not an object for the key [%s]", p, path)
 		}
@@ -271,14 +271,14 @@ func findKeyInJSON(path string, obj map[string]interface{}) (string, error) {
 	return "", fmt.Errorf("error in traversing request JSON, no parts for the key [%s]", path)
 }
 
-func findValueInJSON(path string, obj map[string]interface{}) (interface{}, error) {
+func findValueInJSON(path string, obj map[string]any) (any, error) {
 	parts := strings.Split(path, "/")
-	var current interface{} = obj
+	var current any = obj
 	for i, p := range parts {
 		if p == "" || p == "." {
 			continue
 		}
-		m, ok := current.(map[string]interface{})
+		m, ok := current.(map[string]any)
 		if !ok {
 			return "", fmt.Errorf("error in traversing request JSON, value of [%s] is not an object for the value [%s]", p, path)
 		}

--- a/app/proxy.go
+++ b/app/proxy.go
@@ -69,10 +69,10 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) adjustRedirectURL(location string) string {
 	targetAddr := p.target.String()
 	hostAddr := p.host.String()
-	location = strings.Replace(location, targetAddr, hostAddr, -1)
+	location = strings.ReplaceAll(location, targetAddr, hostAddr)
 	if i := strings.Index(location, "?"); i != -1 {
 		query, _ := url.QueryUnescape(location[i+1:])
-		query = url.QueryEscape(strings.Replace(query, targetAddr, hostAddr, -1))
+		query = url.QueryEscape(strings.ReplaceAll(query, targetAddr, hostAddr))
 		return location[:i] + "?" + query
 	}
 	return location
@@ -83,5 +83,5 @@ func (p *Proxy) adjustRedirectQuery(u *url.URL) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error in decoding query part of the location: %w", err)
 	}
-	return strings.Replace(q, p.target.String(), p.host.String(), -1), nil
+	return strings.ReplaceAll(q, p.target.String(), p.host.String()), nil
 }

--- a/app/store.go
+++ b/app/store.go
@@ -5,49 +5,49 @@ import (
 )
 
 type store struct {
-	table map[string]interface{}
+	table map[string]any
 	lock  sync.RWMutex
 }
 
 func newStore() *store {
 	return &store{
-		table: map[string]interface{}{},
+		table: map[string]any{},
 	}
 }
 
-func (s *store) Write(entity, key string, value interface{}) {
+func (s *store) Write(entity, key string, value any) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	var table map[string]interface{}
+	var table map[string]any
 	v, ok := s.table[entity]
 	if !ok {
-		table = map[string]interface{}{}
+		table = map[string]any{}
 	} else {
-		table = v.(map[string]interface{})
+		table = v.(map[string]any)
 	}
 	table[key] = value
 	s.table[entity] = table
 }
 
-func (s *store) Read(entity, key string) (interface{}, bool) {
+func (s *store) Read(entity, key string) (any, bool) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	v, ok := s.table[entity]
 	if !ok {
 		return nil, false
 	}
-	table := v.(map[string]interface{})
+	table := v.(map[string]any)
 	obj, ok := table[key]
 	return obj, ok
 }
 
-func (s *store) ReadAll(entity string) (map[string]interface{}, bool) {
+func (s *store) ReadAll(entity string) (map[string]any, bool) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	v, ok := s.table[entity]
 	if !ok {
 		return nil, false
 	}
-	table, ok := v.(map[string]interface{})
+	table, ok := v.(map[string]any)
 	return table, ok
 }

--- a/app/util.go
+++ b/app/util.go
@@ -18,7 +18,7 @@ func (wrp *responseWriterWrapper) WriteHeader(code int) {
 }
 
 // readRequestJSON ...
-func readRequestJSON(c context.Context, r *http.Request, object interface{}) *appError {
+func readRequestJSON(_ context.Context, r *http.Request, object any) *appError {
 	err := json.NewDecoder(r.Body).Decode(object)
 	if err != nil {
 		return &appError{

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -128,7 +128,7 @@ func watchConfigFiles(mockPath string, cancelServer context.CancelFunc) {
 	if err != nil {
 		zap.L().Fatal(fmt.Sprintf("failed to create watcher: %v", err))
 	}
-	defer watcher.Close()
+	defer func() { _ = watcher.Close() }()
 
 	err = watcher.Add(mockPath)
 	if err != nil {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -23,10 +23,9 @@ var (
 )
 
 func main() {
-	configFile := flag.String("config", "_resources/config.yml", "Configuration file")
 	mockFile := flag.String("mock", "mock.json", "Mock configuration file")
 	verbose := flag.Bool("verbose", false, "Verbose")
-	ver := flag.Bool("version", false, "prints version of Tagify")
+	ver := flag.Bool("version", false, "prints version of gomock")
 	watch := flag.Bool("watch", false, "Watch config file changes and reload automatically")
 
 	flag.Parse()
@@ -45,11 +44,14 @@ func main() {
 
 	// Server execution loop
 	for {
-		// Load initial configuration
-		cfg, err := config.NewConfig(*configFile)
+		var mck config.Mock
+		var mockPath string
+		mck, mockPath, err := config.NewMock(*mockFile)
 		if err != nil {
-			zap.L().Warn(fmt.Sprintf("failed to load configuration %s: %v", *configFile, err))
+			zap.L().Warn(fmt.Sprintf("failed to load mock configuration %s: %v", *mockFile, err))
 		}
+
+		cfg := mck.ToConfig()
 
 		logLevel := cfg.Logger.Level
 		if *verbose {
@@ -57,13 +59,6 @@ func main() {
 		}
 
 		config.SetupLog(logLevel)
-
-		var mck config.Mock
-		var mockPath string
-		mck, mockPath, err = config.NewMock(*mockFile)
-		if err != nil {
-			zap.L().Warn(fmt.Sprintf("failed to load API configuration %s: %v", *mockFile, err))
-		}
 
 		// Start and monitor server
 		serverCtx, cancelServer := context.WithCancel(context.Background())
@@ -77,7 +72,7 @@ func main() {
 
 		// Enable configuration file monitoring
 		if *watch {
-			go watchConfigFiles(*configFile, *mockFile, cancelServer)
+			go watchConfigFiles(*mockFile, cancelServer)
 		}
 
 		select {
@@ -128,20 +123,16 @@ func runServer(ctx context.Context, cfg *config.Config, mck *config.Mock, versio
 }
 
 // Monitor configuration file changes and restart server
-func watchConfigFiles(configPath, mockPath string, cancelServer context.CancelFunc) {
+func watchConfigFiles(mockPath string, cancelServer context.CancelFunc) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		zap.L().Fatal(fmt.Sprintf("failed to create watcher: %v", err))
 	}
 	defer watcher.Close()
 
-	// Add files to monitor
-	files := []string{configPath, mockPath}
-	for _, file := range files {
-		err = watcher.Add(file)
-		if err != nil {
-			zap.L().Fatal(fmt.Sprintf("failed to watch file %s: %v", file, err))
-		}
+	err = watcher.Add(mockPath)
+	if err != nil {
+		zap.L().Fatal(fmt.Sprintf("failed to watch file %s: %v", mockPath, err))
 	}
 
 	for {

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,7 @@
 package config
 
 import (
-	"os"
 	"time"
-
-	"gopkg.in/yaml.v2"
 )
 
 // Config represents configuration of application.
@@ -18,29 +15,4 @@ type Config struct {
 	Logger struct {
 		Level string
 	}
-}
-
-// NewConfig loads configuration from file.
-func NewConfig(file string) (cfg Config, err error) {
-
-	// Server ...
-	cfg.Server.Addr = ":8080"
-	cfg.Server.ReadTimeout = 5 * time.Second
-	cfg.Server.WriteTimeout = 5 * time.Second
-	cfg.Server.IdleTimeout = 5 * time.Second
-
-	// Logger ...
-	cfg.Logger.Level = "info"
-
-	data, err := os.ReadFile(file)
-
-	if err != nil {
-		return
-	}
-
-	if err = yaml.Unmarshal(data, &cfg); err != nil {
-		return
-	}
-
-	return
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -4,12 +4,55 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 )
 
 // Mock represents configuration of API.
 type Mock struct {
-	Port      int         `json:"port,omitempty"`
-	Endpoints []*Endpoint `json:"endpoints"`
+	Port         int         `json:"port,omitempty"`
+	Addr         string      `json:"addr,omitempty"`
+	ReadTimeout  string      `json:"readTimeout,omitempty"`
+	WriteTimeout string      `json:"writeTimeout,omitempty"`
+	IdleTimeout  string      `json:"idleTimeout,omitempty"`
+	LogLevel     string      `json:"logLevel,omitempty"`
+	Endpoints    []*Endpoint `json:"endpoints"`
+}
+
+// ToConfig converts Mock server settings into a Config with sensible defaults.
+func (m *Mock) ToConfig() Config {
+	var cfg Config
+
+	// Defaults
+	cfg.Server.Addr = ":8080"
+	cfg.Server.ReadTimeout = 5 * time.Second
+	cfg.Server.WriteTimeout = 5 * time.Second
+	cfg.Server.IdleTimeout = 5 * time.Second
+	cfg.Logger.Level = "info"
+
+	// Apply port (addr takes precedence if both set)
+	if m.Port > 0 {
+		cfg.Server.Addr = ":" + strconv.Itoa(m.Port)
+	}
+	if m.Addr != "" {
+		cfg.Server.Addr = m.Addr
+	}
+
+	if d, err := time.ParseDuration(m.ReadTimeout); err == nil {
+		cfg.Server.ReadTimeout = d
+	}
+	if d, err := time.ParseDuration(m.WriteTimeout); err == nil {
+		cfg.Server.WriteTimeout = d
+	}
+	if d, err := time.ParseDuration(m.IdleTimeout); err == nil {
+		cfg.Server.IdleTimeout = d
+	}
+
+	if m.LogLevel != "" {
+		cfg.Logger.Level = m.LogLevel
+	}
+
+	return cfg
 }
 
 // Endpoint represents API endpoint configuration.

--- a/config/mock.go
+++ b/config/mock.go
@@ -62,7 +62,7 @@ type Endpoint struct {
 	Path      string      `json:"path"`
 	Delay     int         `json:"delay,omitempty"`
 	JSONPath  string      `json:"jsonPath,omitempty"` // path to the JSON file with endpoint
-	JSON      interface{} `json:"json,omitempty"`
+	JSON      any `json:"json,omitempty"`
 	Proxy     string      `json:"proxy,omitempty"`
 	Static    string      `json:"static,omitempty"` // static file server
 	Errors    *Errors     `json:"errors,omitempty"`

--- a/config/mock.go
+++ b/config/mock.go
@@ -57,16 +57,16 @@ func (m *Mock) ToConfig() Config {
 
 // Endpoint represents API endpoint configuration.
 type Endpoint struct {
-	Methods   []string    `json:"methods,omitempty"`
-	Status    int         `json:"status,omitempty"`
-	Path      string      `json:"path"`
-	Delay     int         `json:"delay,omitempty"`
-	JSONPath  string      `json:"jsonPath,omitempty"` // path to the JSON file with endpoint
-	JSON      any `json:"json,omitempty"`
-	Proxy     string      `json:"proxy,omitempty"`
-	Static    string      `json:"static,omitempty"` // static file server
-	Errors    *Errors     `json:"errors,omitempty"`
-	AllowCors []string    `json:"allowCors,omitempty"`
+	Methods   []string `json:"methods,omitempty"`
+	Status    int      `json:"status,omitempty"`
+	Path      string   `json:"path"`
+	Delay     int      `json:"delay,omitempty"`
+	JSONPath  string   `json:"jsonPath,omitempty"` // path to the JSON file with endpoint
+	JSON      any      `json:"json,omitempty"`
+	Proxy     string   `json:"proxy,omitempty"`
+	Static    string   `json:"static,omitempty"` // static file server
+	Errors    *Errors  `json:"errors,omitempty"`
+	AllowCors []string `json:"allowCors,omitempty"`
 	Dynamic   *struct {
 		Write *struct {
 			JSON *struct {

--- a/config/mock_test.go
+++ b/config/mock_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToConfig_Defaults(t *testing.T) {
+	m := Mock{}
+	cfg := m.ToConfig()
+
+	assert.Equal(t, ":8080", cfg.Server.Addr)
+	assert.Equal(t, 5*time.Second, cfg.Server.ReadTimeout)
+	assert.Equal(t, 5*time.Second, cfg.Server.WriteTimeout)
+	assert.Equal(t, 5*time.Second, cfg.Server.IdleTimeout)
+	assert.Equal(t, "info", cfg.Logger.Level)
+}
+
+func TestToConfig_PortOverride(t *testing.T) {
+	m := Mock{Port: 9090}
+	cfg := m.ToConfig()
+
+	assert.Equal(t, ":9090", cfg.Server.Addr)
+}
+
+func TestToConfig_AddrOverridesPort(t *testing.T) {
+	m := Mock{Port: 9090, Addr: ":3000"}
+	cfg := m.ToConfig()
+
+	assert.Equal(t, ":3000", cfg.Server.Addr)
+}
+
+func TestToConfig_Timeouts(t *testing.T) {
+	m := Mock{
+		ReadTimeout:  "10s",
+		WriteTimeout: "20s",
+		IdleTimeout:  "30s",
+	}
+	cfg := m.ToConfig()
+
+	assert.Equal(t, 10*time.Second, cfg.Server.ReadTimeout)
+	assert.Equal(t, 20*time.Second, cfg.Server.WriteTimeout)
+	assert.Equal(t, 30*time.Second, cfg.Server.IdleTimeout)
+}
+
+func TestToConfig_InvalidTimeoutKeepsDefault(t *testing.T) {
+	m := Mock{ReadTimeout: "not-a-duration"}
+	cfg := m.ToConfig()
+
+	assert.Equal(t, 5*time.Second, cfg.Server.ReadTimeout)
+}
+
+func TestToConfig_LogLevel(t *testing.T) {
+	m := Mock{LogLevel: "debug"}
+	cfg := m.ToConfig()
+
+	assert.Equal(t, "debug", cfg.Logger.Level)
+}
+
+func TestNewMock_WithServerFields(t *testing.T) {
+	content := `{
+		"port": 9090,
+		"addr": ":3000",
+		"readTimeout": "10s",
+		"writeTimeout": "20s",
+		"idleTimeout": "30s",
+		"logLevel": "debug",
+		"endpoints": [
+			{
+				"path": "/test",
+				"json": {"ok": true}
+			}
+		]
+	}`
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "mock.json")
+	require.NoError(t, os.WriteFile(file, []byte(content), 0644))
+
+	mck, path, err := NewMock(file)
+	require.NoError(t, err)
+	assert.Equal(t, dir, path)
+	assert.Equal(t, 9090, mck.Port)
+	assert.Equal(t, ":3000", mck.Addr)
+	assert.Equal(t, "10s", mck.ReadTimeout)
+	assert.Equal(t, "20s", mck.WriteTimeout)
+	assert.Equal(t, "30s", mck.IdleTimeout)
+	assert.Equal(t, "debug", mck.LogLevel)
+	assert.Len(t, mck.Endpoints, 1)
+	assert.Equal(t, "/test", mck.Endpoints[0].Path)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smeshkov/gomock
 
-go 1.23
+go 1.26
 
 require (
 	github.com/go-chi/chi/v5 v5.2.2

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.13.0
 	gopkg.in/fsnotify.v1 v1.4.7
-	gopkg.in/yaml.v2 v2.2.8
 )
 
 require (
@@ -24,5 +23,6 @@ require (
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
 )


### PR DESCRIPTION
## Summary

- Modernise CI/CD workflows and build tooling
- Remove the separate YAML config file (`_resources/config.yml`) and the `-config` CLI flag
- Add server settings (`addr`, `readTimeout`, `writeTimeout`, `idleTimeout`, `logLevel`) as top-level fields in the mock JSON — one config file, one format
- `port` is still supported; `addr` takes precedence if both are set
- Remove the `yaml.v2` direct dependency

Addresses suggestion #1 from #5 (single config file, avoid mixing formats).

### Example mock.json with server settings

```json
{
  "port": 8080,
  "readTimeout": "300s",
  "writeTimeout": "300s",
  "logLevel": "debug",
  "endpoints": [...]
}
```

## Test plan

- [x] 7 new tests for `ToConfig()` and `NewMock()` covering defaults, port/addr override, timeouts, invalid duration fallback, log level, and full JSON round-trip
- [x] All existing tests pass
- [x] `make checkfmt` and `make vet` pass
- [x] Manual test: run `go run cmd/app/main.go -mock mock.json` with new fields and verify server binds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)