### PR TITLE
Added CLI flags (`-port`, `-addr`, `-log-level`, `-read-timeout`, `-w…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.13.0
+
+- Added CLI flags (`-port`, `-addr`, `-log-level`, `-read-timeout`, `-write-timeout`, `-idle-timeout`) to override mock config values;
+- Added `go run` usage example in README for running without installation.
+
 ## v0.12.0
 
 - Switched to single JSON config file (see "Mock configuration file") and removed yaml config file to avoid mixing formats;

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: deps clean build
 
-TAG=0.12.0
+TAG=0.13.0
 BINARY=gomock
 DIST_DIR=_dist
 OS=darwin

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ For Windows:
 
 ## Usage
 
+### Run without installation
+
+```bash
+go run github.com/smeshkov/gomock/cmd/app@latest -mock /path/to/your/mock.json
+```
+
+### Run with installation
+
 Create JSON file with your mocks and start mock server by running `gomock -mock /path/to/your/mock.json`.
 
 `mock.json` defines mocks - handlers which will serve provided mocks.
@@ -105,6 +113,23 @@ Endpoint object in `endpoints` list:
 - `dynamic` - allows to configure dynamic read/write behaviour, i.e. values can be stored and retrieved from the internal store.
 
 `mock.json` is the default name for a mock configuration file, it can be renamed and set via `-mock` option, e.g. `./gomock -mock api.json`
+
+### CLI flags
+
+All CLI flags override the corresponding values in `mock.json`:
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `-mock` | Path to mock configuration file | `-mock api.json` |
+| `-port` | Server port | `-port 3000` |
+| `-addr` | Server address (overrides `-port`) | `-addr :3000` |
+| `-log-level` | Log level (`info` or `debug`) | `-log-level debug` |
+| `-read-timeout` | Read timeout (Go duration) | `-read-timeout 10s` |
+| `-write-timeout` | Write timeout (Go duration) | `-write-timeout 10s` |
+| `-idle-timeout` | Idle timeout (Go duration) | `-idle-timeout 60s` |
+| `-verbose` | Shorthand for `-log-level debug` | `-verbose` |
+| `-watch` | Watch config file and reload on changes | `-watch` |
+| `-version` | Print version | `-version` |
 
 ## Dynamic mocking
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -27,6 +27,12 @@ func main() {
 	verbose := flag.Bool("verbose", false, "Verbose")
 	ver := flag.Bool("version", false, "prints version of gomock")
 	watch := flag.Bool("watch", false, "Watch config file changes and reload automatically")
+	flagPort := flag.Int("port", 0, "Server port (overrides mock config)")
+	flagAddr := flag.String("addr", "", "Server address e.g. :3000 (overrides port and mock config)")
+	flagLogLevel := flag.String("log-level", "", "Log level: info or debug (overrides mock config)")
+	flagReadTimeout := flag.String("read-timeout", "", "Read timeout as Go duration e.g. 10s (overrides mock config)")
+	flagWriteTimeout := flag.String("write-timeout", "", "Write timeout as Go duration e.g. 10s (overrides mock config)")
+	flagIdleTimeout := flag.String("idle-timeout", "", "Idle timeout as Go duration e.g. 60s (overrides mock config)")
 
 	flag.Parse()
 
@@ -53,12 +59,17 @@ func main() {
 
 		cfg := mck.ToConfig()
 
-		logLevel := cfg.Logger.Level
-		if *verbose {
-			logLevel = "debug"
-		}
+		cfg.ApplyOverrides(config.CLIOverrides{
+			Port:         *flagPort,
+			Addr:         *flagAddr,
+			LogLevel:     *flagLogLevel,
+			Verbose:      *verbose,
+			ReadTimeout:  *flagReadTimeout,
+			WriteTimeout: *flagWriteTimeout,
+			IdleTimeout:  *flagIdleTimeout,
+		})
 
-		config.SetupLog(logLevel)
+		config.SetupLog(cfg.Logger.Level)
 
 		// Start and monitor server
 		serverCtx, cancelServer := context.WithCancel(context.Background())

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strconv"
 	"time"
 )
 
@@ -14,5 +15,41 @@ type Config struct {
 	}
 	Logger struct {
 		Level string
+	}
+}
+
+// CLIOverrides holds CLI flag values that override config settings.
+type CLIOverrides struct {
+	Port         int
+	Addr         string
+	LogLevel     string
+	Verbose      bool
+	ReadTimeout  string
+	WriteTimeout string
+	IdleTimeout  string
+}
+
+// ApplyOverrides applies CLI flag overrides to the config.
+func (c *Config) ApplyOverrides(o CLIOverrides) {
+	if o.Port > 0 {
+		c.Server.Addr = ":" + strconv.Itoa(o.Port)
+	}
+	if o.Addr != "" {
+		c.Server.Addr = o.Addr
+	}
+	if d, err := time.ParseDuration(o.ReadTimeout); err == nil {
+		c.Server.ReadTimeout = d
+	}
+	if d, err := time.ParseDuration(o.WriteTimeout); err == nil {
+		c.Server.WriteTimeout = d
+	}
+	if d, err := time.ParseDuration(o.IdleTimeout); err == nil {
+		c.Server.IdleTimeout = d
+	}
+	if o.LogLevel != "" {
+		c.Logger.Level = o.LogLevel
+	}
+	if o.Verbose {
+		c.Logger.Level = "debug"
 	}
 }

--- a/config/mock_test.go
+++ b/config/mock_test.go
@@ -62,6 +62,72 @@ func TestToConfig_LogLevel(t *testing.T) {
 	assert.Equal(t, "debug", cfg.Logger.Level)
 }
 
+func TestApplyOverrides_Port(t *testing.T) {
+	m := Mock{}
+	cfg := m.ToConfig()
+	cfg.ApplyOverrides(CLIOverrides{Port: 9090})
+
+	assert.Equal(t, ":9090", cfg.Server.Addr)
+}
+
+func TestApplyOverrides_AddrOverridesPort(t *testing.T) {
+	m := Mock{}
+	cfg := m.ToConfig()
+	cfg.ApplyOverrides(CLIOverrides{Port: 9090, Addr: ":3000"})
+
+	assert.Equal(t, ":3000", cfg.Server.Addr)
+}
+
+func TestApplyOverrides_Timeouts(t *testing.T) {
+	m := Mock{}
+	cfg := m.ToConfig()
+	cfg.ApplyOverrides(CLIOverrides{
+		ReadTimeout:  "10s",
+		WriteTimeout: "20s",
+		IdleTimeout:  "30s",
+	})
+
+	assert.Equal(t, 10*time.Second, cfg.Server.ReadTimeout)
+	assert.Equal(t, 20*time.Second, cfg.Server.WriteTimeout)
+	assert.Equal(t, 30*time.Second, cfg.Server.IdleTimeout)
+}
+
+func TestApplyOverrides_InvalidTimeoutKeepsOriginal(t *testing.T) {
+	m := Mock{}
+	cfg := m.ToConfig()
+	cfg.ApplyOverrides(CLIOverrides{ReadTimeout: "bad"})
+
+	assert.Equal(t, 5*time.Second, cfg.Server.ReadTimeout)
+}
+
+func TestApplyOverrides_LogLevel(t *testing.T) {
+	m := Mock{}
+	cfg := m.ToConfig()
+	cfg.ApplyOverrides(CLIOverrides{LogLevel: "debug"})
+
+	assert.Equal(t, "debug", cfg.Logger.Level)
+}
+
+func TestApplyOverrides_VerboseOverridesLogLevel(t *testing.T) {
+	m := Mock{LogLevel: "info"}
+	cfg := m.ToConfig()
+	cfg.ApplyOverrides(CLIOverrides{LogLevel: "info", Verbose: true})
+
+	assert.Equal(t, "debug", cfg.Logger.Level)
+}
+
+func TestApplyOverrides_EmptyKeepsDefaults(t *testing.T) {
+	m := Mock{}
+	cfg := m.ToConfig()
+	cfg.ApplyOverrides(CLIOverrides{})
+
+	assert.Equal(t, ":8080", cfg.Server.Addr)
+	assert.Equal(t, 5*time.Second, cfg.Server.ReadTimeout)
+	assert.Equal(t, 5*time.Second, cfg.Server.WriteTimeout)
+	assert.Equal(t, 5*time.Second, cfg.Server.IdleTimeout)
+	assert.Equal(t, "info", cfg.Logger.Level)
+}
+
 func TestNewMock_WithServerFields(t *testing.T) {
 	content := `{
 		"port": 9090,


### PR DESCRIPTION
…rite-timeout`, `-idle-timeout`) to override mock config values; Added `go run` usage example in README for running without installation.